### PR TITLE
Fix merged check

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -164,7 +164,7 @@ steps:
     link: https://github.com/{{ user.username }}/{{ course.template.name }}/pull/3
     actions:
       - type: gate
-        left: "%merged%"
+        left: "%payload.pull_request.merged%"
         else:
           - type: respond
             with: "reopen.md"


### PR DESCRIPTION
Fixes #1 by adjusting the `gate` action to check for `payload.pull_request.merged` instead of just `merged` (which doesn't exist so is `undefined`, so `falsey`, so the gate doesn't pass and the step can't be completed).