### PR TITLE
There is no pencil icon for editing PR descriptions.

### DIFF
--- a/responses/fix-body.md
+++ b/responses/fix-body.md
@@ -4,7 +4,7 @@ Let's edit this pull request to add a body description.
 
 ## :keyboard: Activity: Fixing your pull request
 
-1. The first comment on your pull request will have the default text of **No description provided**. Click on the **pencil** icon located at the top right corner of the comment box to make an edit
+1. The first comment on your pull request will have the default text of **No description provided**. Click on the **...** icon located at the top right corner of the comment box, then click on **Edit** to make an edit
 1. Add a description of the changes you've made in the comment box. Feel free to add a description of what you’ve accomplished so far. As a reminder, you have: created a branch, created a file and made a commit, and opened a pull request
 1. Click the green **Update comment** button at the bottom right of the comment box when done
 


### PR DESCRIPTION
It's now in an expanding context menu. I just updated the copy to reflect this change.

![There is no spoon. Or pencil.](https://user-images.githubusercontent.com/521866/46463843-323ad000-c7c5-11e8-9d7f-616208b81c48.png)
