### PR TITLE
Display only real branch name, not "refs/heads"

### DIFF
--- a/responses/open-a-pr.md
+++ b/responses/open-a-pr.md
@@ -20,7 +20,7 @@ This pull request is going to keep the changes you just made on your branch and 
 
 1. From the "Pull requests" tab, click **New pull request**
 1. In the "base:" drop-down menu, make sure the "master" branch is selected
-1. In the "compare:" drop-down menu, select "{{ branch | replace('') }}"
+1. In the "compare:" drop-down menu, select "{{ branch | remove: 'refs/heads/' }}"
 1. Click **Create pull request**
 1. When you’ve selected your branch, enter a title for your pull request. For example `Add {{ user.username }}'s file`
 1. The next field helps you provide a description of the changes you made. Feel free to add a description of what you’ve accomplished so far. As a reminder, you have: created a branch, created a file and made a commit, and opened a pull request


### PR DESCRIPTION
While going through learning lab with the participants in training this week, I saw that when opening a pull request, it shows "refs/heads" in addition to the branch name. 

This pull request **attempts** to fix that. I haven't tested locally so I would ❤️ some review if anyone has time to get to it before I do. 

cc @hectorsector @githubtraining/learning-engineering 

<img width="570" alt="screen shot 2018-12-03 at 17 10 49" src="https://user-images.githubusercontent.com/9906718/49385743-69beed80-f71e-11e8-927c-ab6340e941f3.png">
