### PR TITLE
Add issue triage action

### DIFF
--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -1,0 +1,15 @@
+name: Move new issues into Triage
+
+on:
+  issues:
+    types: [opened, reopened]
+
+jobs:
+  automate-project-columns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.1.0
+        with:
+          project: Learning Lab Course maintenance
+          column: Triage
+          repo-token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Adds the issue triage action. This should be ready to go just needs an 👀 -- feel free to merge without me.

Main tracking issue: https://github.com/github/learning-lab-content/issues/14