### PR TITLE
Fixing hard-coded org reference

### DIFF
--- a/responses/reminder-delete.md
+++ b/responses/reminder-delete.md
@@ -29,7 +29,7 @@ To find projects to contribute to through trending topics and curated collection
 ### Keep learning
 
 Here are some suggestions for future courses you can take:
-- [GitHub Pages]({{ host }}/githubtraining/github-pages): Continue learning about GitHub Pages, which we touched on in this course.
-- [Communicating using Markdown]({{ host }}/githubtraining/communicating-using-markdown): We used a little Markdown in this course, but if you want to learn all about this :sparkles: syntax, take the course!
+- [GitHub Pages]({{ host }}/{{ course.Owner.login }}/github-pages): Continue learning about GitHub Pages, which we touched on in this course.
+- [Communicating using Markdown]({{ host }}/{{ course.Owner.login }}/communicating-using-markdown): We used a little Markdown in this course, but if you want to learn all about this :sparkles: syntax, take the course!
 
 [What will you learn next]({{ host }}/courses)?


### PR DESCRIPTION
`githubtraining` was hard-coded.  This does not make it very friendly to GHES where you can install on any org.  Thank you to @JasonEtco for giving me the proper variable to pull for this.

/cc @crichID @brianamarie @hectorsector @JasonEtco