### PR TITLE
Remove tagline

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,4 @@
 title: Introduction to GitHub
-tagline: Your sidekick for getting started on GitHub
 description: If you are looking for a quick and fun introduction to GitHub, you've found it. This class will get you started using GitHub in less than an hour.
 template:
   name: github-slideshow


### PR DESCRIPTION
Since we point to this course as an example for the `config.yml` I'd like to remove the tagline from this course since it is no longer being used by the app.

Including the tagline won't break anything right now, but I'd like to minimize confusion where possible!