### PR TITLE
Update course details header level

### DIFF
--- a/course-details.md
+++ b/course-details.md
@@ -1,11 +1,10 @@
-# Course description
 People use GitHub to build some of the most advanced technologies in the world. Whether you’re visualizing data or building a new game, there’s a whole community and set of tools on GitHub that can help you do it even better.
 
 Now, with GitHub Learning Lab, you’ve got a sidekick along your path to becoming an all-star developer.
 
 From managing notifications to merging pull requests, GitHub Learning Lab’s “Introduction to GitHub” course guides you through everything you need to start contributing in less than an hour. See a word you don't understand? We've included an emoji 📖 next to some key terms. Click on it to see its definition.
 
-# What you'll learn
+## What you'll learn
 
 We'll answer common questions like: 
 - What is GitHub?
@@ -22,20 +21,20 @@ And when you're done you'll be able to:
 - Introduce changes with pull requests
 - Deploy a web page to GitHub pages
 
-# What you'll build
+## What you'll build
 ![a gif of a slide show running on a browser](https://user-images.githubusercontent.com/16547949/69274863-44362880-0ba9-11ea-98f6-b58cfc9eab02.gif)
 
 - Completed [source repository](https://github.com/githubtraining/github-slideshow-demo/)
 - Interactive [slideshow](https://githubtraining.github.io/github-slideshow-demo/) deployed to GitHub Pages.
 
-# Prerequisites
+## Prerequisites
 None. This course is a great introduction for your first day on GitHub.
 
-# Projects used
+## Projects used
 This makes use of the following open source projects. Consider exploring these repos and maybe even making contributions!
 - [reveal.js](https://github.com/hakimel/reveal.js): A framework for creating presentations using HTML
 - [Jekyll](https://github.com/jekyll/jekyll): a simple, blog-aware, static site generator.
 
-# Audience
+## Audience
 
 New developers, new GitHub users, users new to Git, students, managers, teams


### PR DESCRIPTION
This updates the course details page headers from level 1 to level 2.  This makes the size a bit smaller.  It also prevents having multiple h1 tags on the page. I also removed the header for "Course description" so that the first paragraph would get its increased font size.

![Screenshot_2020-02-24 Introduction to GitHub GitHub Learning Lab](https://user-images.githubusercontent.com/1221423/75176660-6c25b280-56e9-11ea-8b98-bdf253ed4712.png)
