### PR TITLE
Fixed the LICENSE path issue in Readme.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ We :heart: our community and take great care to ensure it is fun, safe and rewar
 
 ## License
 
-All Learning Lab course repositories are licensed under [CC-BY-4.0](../LICENSE) (c) 2019 GitHub, Inc. The template repositories associated with each course may have different licenses.
+All Learning Lab course repositories are licensed under [CC-BY-4.0](../master/LICENSE) (c) 2019 GitHub, Inc. The template repositories associated with each course may have different licenses.
 
 When using the GitHub logos, be sure to follow the [GitHub logo guidelines](https://github.com/logos)


### PR DESCRIPTION
Old Path - https://github.com/vaghelabhavesh/introduction-to-github/blob/LICENSE
New Path - https://github.com/vaghelabhavesh/introduction-to-github/blob/master/LICENSE