### PR TITLE
Resize a big gif

### DIFF
--- a/course-details.md
+++ b/course-details.md
@@ -22,7 +22,7 @@ And when you're done you'll be able to:
 - Deploy a web page to GitHub pages
 
 ## What you'll build
-![a gif of a slide show running on a browser](https://user-images.githubusercontent.com/16547949/69274863-44362880-0ba9-11ea-98f6-b58cfc9eab02.gif)
+![a gif of a slide show running on a browser](https://user-images.githubusercontent.com/821071/120042632-79aaa600-bfd8-11eb-81c0-3c0b31776e9a.gif)
 
 - Completed [source repository](https://github.com/githubtraining/github-slideshow-demo/)
 - Interactive [slideshow](https://githubtraining.github.io/github-slideshow-demo/) deployed to GitHub Pages.


### PR DESCRIPTION
Closes https://github.com/github/learning-lab/issues/862.

I download the 6 images and 2 gifs used throughout this course. The size actually looks okay for most (<1 GB):

<img width="553" alt="Screen Shot 2021-05-28 at 5 22 43 PM" src="https://user-images.githubusercontent.com/821071/120043090-56342b00-bfd9-11eb-840e-1d09c5c69138.png">

That last GIF is pretty big (3.7M) so I went ahead and resized it:

https://user-images.githubusercontent.com/821071/120042632-79aaa600-bfd8-11eb-81c0-3c0b31776e9a.gif