### PR TITLE
Update step 2 for moved pages location

### DIFF
--- a/responses/01_turn-on-gh-pages.md
+++ b/responses/01_turn-on-gh-pages.md
@@ -9,7 +9,7 @@ Now, on to business! GitHub Pages allow you to serve a static site from a reposi
 ### :keyboard: Activity: Enable GitHub Pages
 
 1. Click on the [**Settings**]({{ repoUrl }}/settings) tab in this repository
-1. Scroll down to the "GitHub Pages" section
+1. In the sidebar, locate the "Code and automation" section and click on `Pages`
 1. From the "Source" drop down, select **main branch**
 
 > Note: Even though you'll see an option to choose a theme, do not apply a theme at this point. We've protected the code so you can't make unintended changes. You'll have the opportunity to apply a theme when the course is completed. 


### PR DESCRIPTION
This updates the verbage in step 2 to now reference the moved Pages location to the sidebar under the "Code and Automation" section

This closes #75 